### PR TITLE
Update linalg.py doc strings

### DIFF
--- a/thermox/linalg.py
+++ b/thermox/linalg.py
@@ -87,7 +87,7 @@ def expnegm(
     process and calculating the covariance of the samples.
 
     Args:
-        A: Drift matrix.
+        A: Matrix to exponentiate.
         num_samples: Number of samples to be collected.
         dt: Time step.
         burnin: Time-step index corresponding to the end of the burn-in period.
@@ -126,17 +126,17 @@ def expm(
     process and calculating the covariance of the samples.
 
     Args:
-        A: Drift matrix.
+        A: Matrix to exponentiate.
         num_samples: Number of samples to be collected.
         dt: Time step.
         burnin: Time-step index corresponding to the end of the burn-in period.
             Samples before this step are not collected.
         key: JAX random key
-        alpha: float, regularization parameter to ensure diffusion matrix
+        alpha: Regularization parameter to ensure diffusion matrix
             is symmetric positive definite.
 
     Returns:
-        approximate matrix exponential, exp(A).
+        Approximate matrix exponential, exp(A).
     """
     return expnegm(-A, num_samples, dt, burnin, key, alpha)
 
@@ -146,7 +146,7 @@ def autocovariance(samples: Array) -> Array:
     Calculate the autocovariance of a set of samples.
 
     Args:
-        samples: array-like, samples from a stochastic process.
+        samples: Samples from a stochastic process, as an array of shape (num_samples, dimension).
 
     Returns:
         Autocovariance of the samples.


### PR DESCRIPTION
Fixes inconsistency in type annotation and doc strings for multiple linalg functions. Also adds clearer explanation of burn-in parameter.

Closes #23 