### PR TITLE
fixes import of eig from fmmax.utils to fmmax.eig

### DIFF
--- a/thermox/utils.py
+++ b/thermox/utils.py
@@ -1,7 +1,7 @@
 from typing import NamedTuple, Tuple
 from jax import numpy as jnp
 from jax import Array
-from fmmax.utils import (
+from fmmax.eig import (
     eig,
 )  # differentiable and jit-able eigendecomposition, not yet available in jax, see https://github.com/google/jax/issues/2748
 


### PR DESCRIPTION
The location of the `eig` function in fmmax changed from `fmmax.utils.eig` to `fmmax.eig.eig` in version 1.0.0. This causes the following error when installing thermox with pip and importing it:

```
>>> import thermox
Traceback (most recent call last):
  File "<python-input-0>", line 1, in <module>
    import thermox
  File "/home/julian/.conda/envs/thermox/lib/python3.13/site-packages/thermox/__init__.py", line 1, in <module>
    from thermox import linalg
  File "/home/julian/.conda/envs/thermox/lib/python3.13/site-packages/thermox/linalg.py", line 4, in <module>
    from thermox.sampler import sample, sample_identity_diffusion
  File "/home/julian/.conda/envs/thermox/lib/python3.13/site-packages/thermox/sampler.py", line 6, in <module>
    from thermox.utils import (
    ...<4 lines>...
    )
  File "/home/julian/.conda/envs/thermox/lib/python3.13/site-packages/thermox/utils.py", line 4, in <module>
    from fmmax.utils import (
    ^^^^^^^^^^^^^^^^^^^^^^^^^
        eig,
        ^^^^
    )  # differentiable and jit-able eigendecomposition, not yet available in jax, see https://github.com/google/jax/issues/2748
    ^
ImportError: cannot import name 'eig' from 'fmmax.utils' (/home/julian/.conda/envs/thermox/lib/python3.13/site-packages/fmmax/utils.py)
```

This trivial PR fixes the above issue. I ran `pre-commit run --all-files` and everything passed.